### PR TITLE
Switching from Guzzle to CURL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "require-dev": {
     "phpunit/phpunit": "4.2.*"
   },
+  "lib-curl": "*",
   "autoload": {
     "psr-0": { 
       "White": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "49029aaba6518a927cbbb4f4d676d909",
+    "hash": "99e6c9ed97abfb9093a26fa2db754775",
     "packages": [
 
     ],

--- a/src/White.php
+++ b/src/White.php
@@ -72,11 +72,8 @@ class White
     return self::$baseURL . self::$endpoints[$name];
   }
 
-  public static function handleErrors(\Exception $e)
-  {
-      $code = $e->getResponse()->getStatusCode();
-      $result = $e->getResponse()->json();
-      
+  public static function handleErrors($result, $code)
+  {   
       if($code == White_Error_Card::$CODE && $result['error']['type'] == White_Error_Card::$TYPE) {
         throw new White_Error_Card($result['error']['message'], $result['error']['code']);
       }

--- a/src/White/Charge.php
+++ b/src/White/Charge.php
@@ -31,8 +31,16 @@ class White_Charge
     curl_setopt($ch,CURLOPT_POSTFIELDS, http_build_query($data));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     $result = json_decode(curl_exec($ch), true);
-    if(curl_errno($ch)){
+
+    // Check for errors and such.
+    $info = curl_getinfo($ch);
+    $errno = curl_errno($ch);
+    if( $result === false || $errno != 0 ) {
+      // Do error checking
       throw new Exception(curl_error($ch));
+    } else if($info['http_code'] != 200) {
+      // Got a non-200 error code.
+      White::handleErrors($result, $info['http_code']);
     }
     curl_close($ch);
 
@@ -57,8 +65,16 @@ class White_Charge
     curl_setopt($ch, CURLOPT_USERPWD, White::getApiKey() . ':');
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     $result = json_decode(curl_exec($ch), true);
-    if(curl_errno($ch)){
+    
+    // Check for errors and such.
+    $info = curl_getinfo($ch);
+    $errno = curl_errno($ch);
+    if( $result === false || $errno != 0 ) {
+      // Do error checking
       throw new Exception(curl_error($ch));
+    } else if($info['http_code'] != 200) {
+      // Got a non-200 error code.
+      White::handleErrors($result, $info['http_code']);
     }
     curl_close($ch);
 


### PR DESCRIPTION
Having lots of issues with customers not supporting the PHP5.4+ version required for Guzzle. Switching back to good 'ole CURL
